### PR TITLE
Add Widgets

### DIFF
--- a/src/accessvis/__init__.py
+++ b/src/accessvis/__init__.py
@@ -4,6 +4,7 @@ import sys
 from . import _version
 from .earth import *
 from .utils import *
+from .widgets import *
 
 # Add current directory to sys.path because python is deranged
 sys.path.append(os.path.dirname(__file__))

--- a/src/accessvis/widgets/__init__.py
+++ b/src/accessvis/widgets/__init__.py
@@ -1,0 +1,6 @@
+from .widget_base import Widget, WidgetMPL, list_widgets
+from .season_widget import SeasonWidget
+from .calendar_widget import CalendarWidget
+from .clock_widget import ClockWidget
+from .image_widget import ImageWidget
+from .text_widget import TextWidget

--- a/src/accessvis/widgets/calendar_widget.py
+++ b/src/accessvis/widgets/calendar_widget.py
@@ -1,0 +1,65 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import calendar
+import datetime
+from .widget_base import WidgetMPL
+
+class CalendarWidget(WidgetMPL):
+    def __init__(self,lv, text_colour='black', **kwargs):
+        super().__init__(lv=lv, **kwargs)
+        self.text_colour = text_colour
+        self.arrow = None
+
+    def _make_mpl(self):
+
+        plt.rc('axes', linewidth=4)
+        plt.rc('font', weight='bold')
+        fig, ax = plt.subplots(subplot_kw={'projection': 'polar'}, figsize=(5, 5))
+        fig.patch.set_facecolor((0, 0, 0, 0))  # make background transparent
+        ax.set_facecolor('white')  # adds a white ring around edge
+
+        # Setting up grid
+        ax.set_rticks([])
+        ax.grid(False)
+        ax.set_theta_zero_location('NW')
+        ax.set_theta_direction(-1)
+
+        # Label Angles
+        MONTH = []
+        for i in range(1, 13):
+            MONTH.append(calendar.month_name[i][0])
+        MONTH = np.roll(MONTH, 2)
+        ANGLES = np.linspace(0.0, 2 * np.pi, 12, endpoint=False)
+        ax.tick_params(axis='x', which='major', pad=12, labelcolor=self.text_colour)
+        ax.set_xticks(ANGLES)
+        ax.set_xticklabels(MONTH, size=20)
+        ax.spines['polar'].set_color(self.text_colour)
+
+        # Make Colours:
+        ax.bar(x=0, height=10, width=np.pi * 2, color='black')
+        for i in range(12):
+            c = 'darkorange' if i % 2 else 'darkcyan'
+            ax.bar(x=i * np.pi / 6, height=10, width=np.pi / 6, color=c)
+
+        return fig, ax
+
+
+    def _update_mpl(self, fig, ax, date: datetime.datetime = None, show_year=True):
+        if show_year:
+            title = str(date.year)
+        else:
+            title = ''
+        fig.suptitle(title, fontsize=20, fontweight='bold', y=0.08, color=self.text_colour)
+
+        if date is None:
+            return
+        else:
+            day_of_year = date.timetuple().tm_yday - 1
+            position = day_of_year / 365. * np.pi * 2.0
+            self.arrow = ax.arrow(position, 0, 0, 8.5, facecolor='#fff', width=0.1, head_length=2,
+                                  edgecolor="black")  # , zorder=11, width=1)
+
+    def _reset_mpl(self, fig, ax, **kwargs):
+        fig.suptitle('')
+        if self.arrow is not None:
+            self.arrow.remove()

--- a/src/accessvis/widgets/calendar_widget.py
+++ b/src/accessvis/widgets/calendar_widget.py
@@ -45,7 +45,7 @@ class CalendarWidget(WidgetMPL):
 
 
     def _update_mpl(self, fig, ax, date: datetime.datetime = None, show_year=True):
-        if show_year:
+        if show_year and date is not None:
             title = str(date.year)
         else:
             title = ''

--- a/src/accessvis/widgets/clock_widget.py
+++ b/src/accessvis/widgets/clock_widget.py
@@ -1,0 +1,60 @@
+import datetime
+from .widget_base import WidgetMPL
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class ClockWidget(WidgetMPL):
+    def __init__(self, lv, text_colour='black', background='white',
+                 show_seconds=False, show_minutes=True, show_hours=True, **kwargs):
+        super().__init__(lv=lv, **kwargs)
+        self.text_colour = text_colour
+        self.background = background
+        self.show_hours = show_hours
+        self.show_minutes = show_minutes
+        self.show_seconds = show_seconds
+        self.lines = []
+
+    # based on https://inprogrammer.com/analog-clock-python/
+    def _make_mpl(self):
+        fig = plt.figure(figsize=(2.5, 2.5), dpi=100)
+        fig.patch.set_facecolor((0, 0, 0, 0))  # make background transparrent
+        ax = fig.add_subplot(111, polar=True)
+        plt.setp(ax.get_yticklabels(), visible=False)
+        ax.set_xticks(np.linspace(0, 2 * np.pi, 12, endpoint=False))
+        ax.set_xticklabels(range(1, 13))
+        ax.tick_params(axis='x', which='major', labelcolor=self.text_colour)
+        ax.set_theta_direction(-1)
+        ax.set_theta_offset(np.pi / 3.0)
+        ax.grid(False)
+        plt.ylim(0, 1)
+
+        ax.set_facecolor(self.background)
+        ax.spines['polar'].set_color(self.text_colour)
+
+        return fig, ax
+
+    def _update_mpl(self, fig, ax, time: datetime.time = None, **kwargs):
+        hour = time.hour
+        minute = time.minute
+        second = time.second
+        angles_h = 2 * np.pi * hour / 12 + 2 * np.pi * minute / (12 * 60) + 2 * second / (12 * 60 * 60) - np.pi / 6.0
+        angles_m = 2 * np.pi * minute / 60 + 2 * np.pi * second / (60 * 60) - np.pi / 6.0
+        angles_s = 2 * np.pi * second / 60 - np.pi / 6.0
+        if time is None:
+            return
+
+        if self.show_seconds:
+            lines = ax.plot([angles_s, angles_s], [0, 0.9], color=self.text_colour, linewidth=1)
+            self.lines.extend(lines)
+        if self.show_minutes:
+            lines = ax.plot([angles_m, angles_m], [0, 0.7], color=self.text_colour, linewidth=2)
+            self.lines.extend(lines)
+        if self.show_hours:
+            lines = ax.plot([angles_h, angles_h], [0, 0.3], color=self.text_colour, linewidth=4)
+            self.lines.extend(lines)
+
+    def _reset_mpl(self, fig, ax, **kwargs):
+        for i in self.lines:
+            i.remove()
+        self.lines.clear()

--- a/src/accessvis/widgets/clock_widget.py
+++ b/src/accessvis/widgets/clock_widget.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 class ClockWidget(WidgetMPL):
-    def __init__(self, lv, text_colour='black', background='white',
+    def __init__(self, lv, text_colour='white', background='black',
                  show_seconds=False, show_minutes=True, show_hours=True, **kwargs):
         super().__init__(lv=lv, **kwargs)
         self.text_colour = text_colour

--- a/src/accessvis/widgets/clock_widget.py
+++ b/src/accessvis/widgets/clock_widget.py
@@ -18,7 +18,7 @@ class ClockWidget(WidgetMPL):
     # based on https://inprogrammer.com/analog-clock-python/
     def _make_mpl(self):
         fig = plt.figure(figsize=(2.5, 2.5), dpi=100)
-        fig.patch.set_facecolor((0, 0, 0, 0))  # make background transparrent
+        fig.patch.set_facecolor((0, 0, 0, 0))  # make background transparent
         ax = fig.add_subplot(111, polar=True)
         plt.setp(ax.get_yticklabels(), visible=False)
         ax.set_xticks(np.linspace(0, 2 * np.pi, 12, endpoint=False))

--- a/src/accessvis/widgets/clock_widget.py
+++ b/src/accessvis/widgets/clock_widget.py
@@ -35,14 +35,15 @@ class ClockWidget(WidgetMPL):
         return fig, ax
 
     def _update_mpl(self, fig, ax, time: datetime.time = None, **kwargs):
+        if time is None:
+            return
+
         hour = time.hour
         minute = time.minute
         second = time.second
         angles_h = 2 * np.pi * hour / 12 + 2 * np.pi * minute / (12 * 60) + 2 * second / (12 * 60 * 60) - np.pi / 6.0
         angles_m = 2 * np.pi * minute / 60 + 2 * np.pi * second / (60 * 60) - np.pi / 6.0
         angles_s = 2 * np.pi * second / 60 - np.pi / 6.0
-        if time is None:
-            return
 
         if self.show_seconds:
             lines = ax.plot([angles_s, angles_s], [0, 0.9], color=self.text_colour, linewidth=1)

--- a/src/accessvis/widgets/image_widget.py
+++ b/src/accessvis/widgets/image_widget.py
@@ -1,0 +1,15 @@
+import numpy as np
+import imageio
+
+from .widget_base import Widget
+
+
+class ImageWidget(Widget):
+    def __init__(self, lv, file_path: str, **kwargs):
+        super().__init__(lv, **kwargs)
+        self.file_path = file_path
+
+    def _make_pixels(self, *args, **kwargs):
+        img = imageio.imread(self.file_path)
+        array = np.asarray(img)
+        return array

--- a/src/accessvis/widgets/screen.frag
+++ b/src/accessvis/widgets/screen.frag
@@ -1,0 +1,36 @@
+
+in vec4 vColour;
+in vec3 vVertex;
+in vec2 vTexCoord; // scale 0 .. 1
+
+//Custom uniform
+uniform sampler2D uTexture;
+uniform float  widthToHeight = 1; // 1 means square, 2 means width is double height
+uniform float scale = 0.5; // Scale down to half the height of the box
+uniform vec2 offset = vec2(0,0);
+
+out vec4 outColour;
+
+void main(void)
+{
+  vec2 size = vec2(scale*widthToHeight, scale);
+  vec2 texCoord = vTexCoord/size;
+  texCoord.y = 1-texCoord.y;
+
+  texCoord.x += (1 - 1/size.x) * offset.x;
+  texCoord.y += (1/size.y - 1) * offset.y;
+
+
+  
+  if (texCoord.x >= 0.0 && texCoord.y >= 0.0 && texCoord.x <= 1.0 && texCoord.y <= 1.0)
+    outColour = texture(uTexture, texCoord);
+  else
+    discard;
+
+  //Discard transparent to skip depth write
+  //This fixes depth buffer output interfering with other objects
+  // in transparent areas
+  if (outColour.a <= 0.1)
+    discard;
+}
+

--- a/src/accessvis/widgets/screen.vert
+++ b/src/accessvis/widgets/screen.vert
@@ -1,0 +1,29 @@
+in vec3 aVertexPosition;
+in vec3 aVertexNormal;
+in vec4 aVertexColour;
+in vec2 aVertexTexCoord;
+
+uniform mat4 uMVMatrix;
+uniform mat4 uPMatrix;
+uniform mat4 uNMatrix;
+
+uniform vec4 uColour;
+
+out vec4 vColour;
+out vec3 vVertex;
+out vec3 vNormal;
+out vec2 vTexCoord;
+void main(void) {
+  gl_Position = vec4(aVertexPosition, 1.0);
+
+  vNormal = normalize(mat3(uNMatrix) * aVertexNormal);
+
+  if (uColour.a > 0.0)
+    vColour = uColour;
+  else
+    vColour = aVertexColour;
+
+  vTexCoord = aVertexTexCoord;
+  vVertex = aVertexPosition;
+}
+

--- a/src/accessvis/widgets/season_widget.py
+++ b/src/accessvis/widgets/season_widget.py
@@ -1,0 +1,64 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import datetime
+
+from .widget_base import WidgetMPL
+
+class SeasonWidget(WidgetMPL):
+    # TODO: Change colours so summer colour starts in december, not jan.
+    # Consider adding in astronomical seasons (solstices).
+    def __init__(self, lv, text_colour='black', hemisphere='south', **kwargs):
+        super().__init__(lv=lv, **kwargs)
+        self.text_colour = text_colour
+        self.hemisphere = hemisphere
+        self.arrow = None
+
+    def _make_mpl(self):
+        plt.rc('axes', linewidth=4)
+        plt.rc('font', weight='bold')
+        fig, ax = plt.subplots(subplot_kw={'projection': 'polar'}, figsize=(5, 5))
+        fig.patch.set_facecolor((0, 0, 0, 0))  # make background transparrent
+        ax.set_facecolor('white')  # adds a white ring around edge
+
+        # Setting up grid
+        ax.set_rticks([])
+        ax.grid(False)
+        ax.set_theta_zero_location('NW')
+        ax.set_theta_direction(-1)
+
+        # Label Angles
+        MONTH = ['Jan', 'Apr', 'Jul', 'Oct']
+        ANGLES = np.linspace(0.0, 2 * np.pi, 4, endpoint=False)
+        ax.tick_params(axis='x', which='major', pad=12, labelcolor=self.text_colour)
+        ax.set_xticks(ANGLES)
+        ax.set_xticklabels(MONTH, size=20)
+        ax.spines['polar'].set_color(self.text_colour)
+
+        # Make Colours:
+        ax.bar(x=0, height=10, width=np.pi * 2, color='black')
+        ax.bar(x=5 * np.pi / 4, height=10, width=np.pi / 2,
+               color='darkcyan' if self.hemisphere == 'south' else 'darkorange')  # Southern Winter
+        ax.bar(x=np.pi / 4, height=10, width=np.pi / 2,
+               color='darkorange' if self.hemisphere == 'south' else 'darkcyan')  # Southern Summer
+
+        return fig, ax
+
+    def _update_mpl(self, fig, ax, date: datetime.datetime = None, show_year=True):
+        if show_year and date is not None:
+            title = str(date.year)
+        else:
+            title = ''
+        fig.suptitle(title, fontsize=20, fontweight='bold', y=0.08, color=self.text_colour)
+
+        if date is None:
+            return
+        else:
+            day_of_year = date.timetuple().tm_yday - 1
+            position = day_of_year / 365. * np.pi * 2.0
+            self.arrow = ax.arrow(position, 0, 0, 8.5, facecolor='#fff', width=0.1, head_length=2,
+                                  edgecolor="black")  # , zorder=11, width=1)
+
+    def _reset_mpl(self, fig, ax, **kwargs):
+        fig.suptitle('')
+        if self.arrow is not None:
+            self.arrow.remove()

--- a/src/accessvis/widgets/text_widget.py
+++ b/src/accessvis/widgets/text_widget.py
@@ -9,17 +9,20 @@ class TextWidget(WidgetMPL):
         self.height = height
         self.text_colour = text_colour
         self.background = background
+        self.text = None
 
     def _make_mpl(self):
         fig, ax = plt.subplots(figsize=(self.width / 100, self.height / 100), dpi=100)
         fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
         ax.set_axis_off()
         fig.patch.set_facecolor(self.background)
+        self.text = ax.text(0.5, 0.5, '', ha='center', va='center', fontsize=20, color=self.text_colour)
 
         return fig, ax
 
     def _update_mpl(self, fig, ax, text='', **kwargs):
-        ax.text(0.5, 0.5, text, ha='center', va='center', fontsize=20, color=self.text_colour)
+        self.text.set_text(text)
 
     def _reset_mpl(self, fig, ax, **kwargs):
-        pass
+        self.text.set_text('')
+

--- a/src/accessvis/widgets/text_widget.py
+++ b/src/accessvis/widgets/text_widget.py
@@ -1,0 +1,25 @@
+import matplotlib.pyplot as plt
+from .widget_base import WidgetMPL
+
+
+class TextWidget(WidgetMPL):
+    def __init__(self, lv, width=300, height=50, text_colour='black', background=(0, 0, 0, 0), **kwargs):
+        super().__init__(lv, **kwargs)
+        self.width = width
+        self.height = height
+        self.text_colour = text_colour
+        self.background = background
+
+    def _make_mpl(self):
+        fig, ax = plt.subplots(figsize=(self.width / 100, self.height / 100), dpi=100)
+        fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
+        ax.set_axis_off()
+        fig.patch.set_facecolor(self.background)
+
+        return fig, ax
+
+    def _update_mpl(self, fig, ax, text='', **kwargs):
+        ax.text(0.5, 0.5, text, ha='center', va='center', fontsize=20, color=self.text_colour)
+
+    def _reset_mpl(self, fig, ax, **kwargs):
+        pass

--- a/src/accessvis/widgets/widget_base.py
+++ b/src/accessvis/widgets/widget_base.py
@@ -1,0 +1,86 @@
+from abc import ABC, abstractmethod
+from functools import cached_property
+import numpy as np
+import os
+
+from ..earth import Settings
+
+
+class Widget(ABC):
+    def __init__(self, lv, scale=0.2, offset=(0, 0)):
+        self.overlay = None
+        self.scale = scale  # between 0 and 1
+        self.offset = offset
+        self.lv = lv
+
+    def make_overlay(self):
+        self.remove()  # Only one overlay.
+
+        pixels = self._make_pixels()
+        pixels[::, ::, ::] = 0
+        y, x, c = np.shape(pixels)
+
+        vert_path = os.path.join(Settings.INSTALL_PATH, 'widgets', 'screen.vert')
+        frag_path = os.path.join(Settings.INSTALL_PATH, 'widgets', 'screen.frag')
+
+        self.overlay = self.lv.screen(shaders=[vert_path, frag_path], vertices=[[0, 0, 0]], texture="blank.png")
+
+        self.lv.set_uniforms(self.overlay['name'], scale=self.scale, offset=self.offset, widthToHeight=x / y)
+        self.overlay.texture(pixels)  # Clear texture with transparent image
+
+    @abstractmethod
+    def _make_pixels(self, **kwargs):
+        pass
+
+    def add_widget(self, **kwargs):
+        if self.overlay is None:
+            self.make_overlay()
+
+        pixels = self._make_pixels(**kwargs)
+        self.overlay.texture(pixels)
+
+    def remove(self):
+        if self.overlay is not None:
+            self.lv.delete(self.overlay['name'])
+            self.overlay = None
+            self.lv = None
+
+
+class WidgetMPL(Widget):
+    @abstractmethod
+    def _make_mpl(self):
+        # Make the basic matplotlib image
+        # returns Figure, Axis
+        raise NotImplementedError
+
+    @abstractmethod
+    def _update_mpl(self, fig, ax, **kwargs):
+        # Update for an animation - e.g. you may want to move an arrow across time
+        raise NotImplementedError
+
+    @abstractmethod
+    def _reset_mpl(self, fig, ax, **kwargs):
+        # This is called after _update_mpl to reset it to the previous state.
+        # e.g. remove an arrow added.
+        # This should leave fig, ax as the same as when first created with _make_mpl()
+        raise NotImplementedError
+
+    @cached_property
+    def _cache_mpl(self):  # only create base MPL once.
+        return self._make_mpl()
+
+    def _make_pixels(self, **kwargs):
+        fig, ax = self._cache_mpl
+        self._update_mpl(fig=fig, ax=ax, **kwargs)
+
+        canvas = fig.canvas
+        canvas.draw()
+        pixels = np.asarray(canvas.buffer_rgba())
+
+        self._reset_mpl(fig=fig, ax=ax, **kwargs)
+
+        return pixels
+
+
+def list_widgets():
+    return [cls.__name__ for cls in Widget.__subclasses__()]

--- a/src/accessvis/widgets/widget_base.py
+++ b/src/accessvis/widgets/widget_base.py
@@ -32,7 +32,7 @@ class Widget(ABC):
     def _make_pixels(self, **kwargs):
         pass
 
-    def add_widget(self, **kwargs):
+    def update_widget(self, **kwargs):
         if self.overlay is None:
             self.make_overlay()
 
@@ -69,17 +69,28 @@ class WidgetMPL(Widget):
     def _cache_mpl(self):  # only create base MPL once.
         return self._make_mpl()
 
-    def _make_pixels(self, **kwargs):
-        fig, ax = self._cache_mpl
-        self._update_mpl(fig=fig, ax=ax, **kwargs)
+    @property
+    def fig(self):
+        return self._cache_mpl[0]
 
-        canvas = fig.canvas
+    @property
+    def ax(self):
+        return self._cache_mpl[1]
+
+    def _make_pixels(self, **kwargs):
+        self._update_mpl(fig=self.fig, ax=self.ax, **kwargs)
+
+        canvas = self.fig.canvas
         canvas.draw()
         pixels = np.asarray(canvas.buffer_rgba())
 
-        self._reset_mpl(fig=fig, ax=ax, **kwargs)
+        self._reset_mpl(fig=self.fig, ax=self.ax, **kwargs)
 
         return pixels
+
+    def show_mpl(self, **kwargs):
+        self._update_mpl(fig=self.fig, ax=self.ax, **kwargs)
+        self._reset_mpl(fig=self.fig, ax=self.ax, **kwargs)
 
 
 def list_widgets():

--- a/src/accessvis/widgets/widget_base.py
+++ b/src/accessvis/widgets/widget_base.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 from functools import cached_property
+
+import matplotlib.pyplot as plt
 import numpy as np
 import os
 
@@ -48,7 +50,7 @@ class Widget(ABC):
 
 class WidgetMPL(Widget):
     @abstractmethod
-    def _make_mpl(self):
+    def _make_mpl(self) -> tuple[plt.Figure, plt.Axes]:
         # Make the basic matplotlib image
         # returns Figure, Axis
         raise NotImplementedError


### PR DESCRIPTION
This pull request will close [issue 34](https://github.com/ACCESS-NRI/ACCESS-Vis/issues/34)
It adds in a clock, season dial, month dial, text, image widgets, and an abstract class to help creation of matplotlib plots.

Example usage:

```
import accessvis
from datetime import datetime

lv = accessvis.plot_earth(texture='bluemarble', waves=True, background='black', vertical_exaggeration=30, )
lv.set_properties(diffuse=0.6, ambient=0.85, specular=0.25, shininess=0.03, light=[1,1,0.98,1], lightpos=[0,0,10000,1])
lv.display(resolution=(600,600))

accessvis.TextWidget(lv=lv, text_colour = 'white', scale=0.1, offset=(1,1)).add_widget(text='Example text')
accessvis.CalendarWidget(lv=lv, text_colour = 'white', scale=0.2, offset=(0,0)).add_widget(date=datetime.now())
accessvis.SeasonWidget(lv=lv, text_colour = 'white', scale=0.2, offset=(0,1)).add_widget(date=datetime.now())
accessvis.ClockWidget(lv=lv, text_colour = 'white', background = 'black', scale=0.3, offset=(1,0)).add_widget(time=datetime.now())
accessvis.ImageWidget(lv=lv, scale=0.2, offset=(0.5,0.5), file_path='/g/data/tm70/mp7041/ACCESS-Visualisation-Recipes/a.png').add_widget()
lv.display(resolution=(600,600))
```

 