### PR TITLE
Fixes for headless rendering on gadi, CPU and GPU with latest lv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
   "pillow",
   "py360convert",
   "matplotlib",
+  "requests",
   "wget",
   "numpy",
   "numpy-quaternion",


### PR DESCRIPTION
LavaVu handles the context now, just set the LV_CONTEXT when running on gadi based on GPU availability - not strictly necessary to do anything as lv handles it but doing this avoids the EGL warning when testing moderngl context availability without a GPU available