### PR TITLE
vector height changable if no alt provided

### DIFF
--- a/src/accessvis/earth.py
+++ b/src/accessvis/earth.py
@@ -2191,7 +2191,8 @@ def plot_vectors_xr(
         try:
             alt = arr[alt_name].to_numpy()
         except KeyError:
-            alt = 0
+            # If no altitude, the height is controlled by alt_scale_factor.
+            alt = max_alt
 
         # Basis vector directions, on the 3d model.
         normal = latlon_normal_vector(lat, lon)


### PR DESCRIPTION
If altitude is not provided in the data, this change allows you to set the altitude for all vectors via `alt_scale_factor`. (set alt_scale_factor=0 to put vectors on the surface again).